### PR TITLE
Remove en-us from docs.microsoft.com links

### DIFF
--- a/src/framework.fsx
+++ b/src/framework.fsx
@@ -40,8 +40,8 @@ type Release =
       NewFeaturesLink : Url option
       NewAccessibilityLink : Url option }
 
-let [<Literal>] msDocsUrl = "https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/versions-and-dependencies"
-let [<Literal>] lifecycleUrl = "https://docs.microsoft.com/en-us/lifecycle/products/microsoft-net-framework"
+let [<Literal>] msDocsUrl = "https://docs.microsoft.com/dotnet/framework/migration-guide/versions-and-dependencies"
+let [<Literal>] lifecycleUrl = "https://docs.microsoft.com/lifecycle/products/microsoft-net-framework"
 
 type MsDocs = HtmlProvider<msDocsUrl, Encoding = "UTF-8">
 type Lifecycle = HtmlProvider<lifecycleUrl, Encoding = "UTF-8">


### PR DESCRIPTION
This will open the documentation is the user preferred language rather than the hard-coded en-us